### PR TITLE
Make Clockify API client asynchronous

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,14 @@
+# ion8 internal changelog
+
+## 0.2.0
+
+Made library async, switched from requests to httpx - jeff@ion8.net
+
+## 0.1.1
+
+Added custom fields patch from Anthony Floyd's fork.
+Added get_projects pagination patch from Eduard Germis' fork.
+
+## 0.1.0
+
+Initial fork from https://github.com/group-eluvia-com/clockify-api-client.

--- a/README.md
+++ b/README.md
@@ -1,19 +1,21 @@
 # Clockify API Client
 
 # Simple API client for Clockify.
-Simple Python API client for Clockify. [Clockify API reference](https://clockify.me/developers-api)
+
+Simple Python API client for
+Clockify. [Clockify API reference](https://clockify.me/developers-api)
 
 - Base endpoints
-  - Client
-  - Project
-  - Task  
-  - Time Entry
-  - User
-  - Workspace
+    - Client
+    - Custom Field
+    - Project
+    - Task
+    - Time Entry
+    - User
+    - Workspace
 - Reports Endpoints
-  - Reports
-  - Shared reports
-
+    - Reports
+    - Shared reports
 
 ## 1. Installation
 
@@ -23,17 +25,41 @@ Add package to your project:
 pipenv install clockify-api-client
 ```
 
-## 2. Usage
-
+## 2. Example usage
 
 ```python
 from clockify_api_client.client import ClockifyAPIClient
 
-API_KEY = 'yourclockifyAPIkey'
-API_URL = 'api.clockify.me/v1'
+CK_API_KEY = "ZWQ5ZjQ2NDMtY2I2NS00OTQ2LTllZGEtNTkzZGMwMjgxODcy"
+CK_API_DOMAIN = "developer.clockify.me"
 
-client = ClockifyAPIClient().build(API_KEY, API_URL)
 
-workspaces = client.workspaces.get_workspaces()  # Returns list of workspaces.
+async def main():
+    api = ClockifyAPIClient().build(
+        CK_API_KEY,
+        f"{CK_API_DOMAIN}/api/v1",
+    )
+    workspaces = await api.workspaces.get_workspaces()
 
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())
 ```
+
+## Developing against a local copy
+
+If you want to make changes to this API client locally and test
+[timekeeper](https://github.com/ion8/timekeeper) against those changes before committing
+them:
+
+1. Install this client once the normal way. This will ensure that the API client
+   dependencies are installed in the timekeeper venv.
+2. Clone https://github.com/ion8/clockify-api-client to a new project.
+2. In a separate run configuration on the timekeeper project, set the environment
+   variable `PYTHONPATH` to the directory with your copy of the API
+   client. (This can't be set in `.env` because `.env` is loaded by `python-dotenv`
+   after Python starts.)
+3. Run timekeeper for development as normal. It will load `clockify-api-client` from
+   PYTHONPATH, overriding the normal import from your project dependencies.

--- a/clockify_api_client/abstract_clockify.py
+++ b/clockify_api_client/abstract_clockify.py
@@ -1,6 +1,6 @@
 from abc import ABC
 
-import requests
+import httpx
 
 
 class AbstractClockify(ABC):
@@ -13,33 +13,37 @@ class AbstractClockify(ABC):
         self.api_key = api_key
         self.header = {'X-Api-Key': self.api_key}
 
-    def get(self, url):
-        response = requests.get(url, headers=self.header)
+    async def get(self, url):
+        async with httpx.AsyncClient() as client:
+            response = await client.get(url, headers=self.header)
         if response.status_code in [200, 201, 202]:
             return response.json()
         raise Exception(response.json())
 
-    def post(self, url, payload):
-        response = requests.post(url, headers=self.header, json=payload)
+    async def post(self, url, payload):
+        async with httpx.AsyncClient() as client:
+            response = await client.post(url, headers=self.header, json=payload)
         if response.status_code in [200, 201, 202]:
             return response.json()
         raise Exception(response.json())
 
-    def put(self, url, payload):
-        response = requests.put(url, headers=self.header, json=payload)
+    async def put(self, url, payload):
+        async with httpx.AsyncClient() as client:
+            response = await client.put(url, headers=self.header, json=payload)
         if response.status_code in [200, 201, 202]:
             return response.json()
         raise Exception(response.json())
 
-    def delete(self, url):
-        response = requests.delete(url, headers=self.header)
+    async def delete(self, url):
+        async with httpx.AsyncClient() as client:
+            response = await client.delete(url, headers=self.header)
         if response.status_code in [200, 201, 202, 204]:
             return response.json()
         raise Exception(response.json())
 
-    def patch(self, url, payload):
-        response = requests.patch(url, headers=self.header, json=payload)
+    async def patch(self, url, payload):
+        async with httpx.AsyncClient() as client:
+            response = await client.patch(url, headers=self.header, json=payload)
         if response.status_code in [200, 201, 202, 204]:
             return response.json()
         raise Exception(response.json())
-

--- a/clockify_api_client/abstract_clockify.py
+++ b/clockify_api_client/abstract_clockify.py
@@ -6,7 +6,10 @@ import requests
 class AbstractClockify(ABC):
     def __init__(self, api_key, api_url):
 
-        self.base_url = f'https://global.{api_url}'.strip('/')
+        # Current API docs don't contain the "global" and the response time
+        # seems faster without it (although it works fine)
+        # self.base_url = f'https://global.{api_url}'.strip('/')
+        self.base_url = f'https://{api_url}'.strip('/')
         self.api_key = api_key
         self.header = {'X-Api-Key': self.api_key}
 
@@ -33,3 +36,10 @@ class AbstractClockify(ABC):
         if response.status_code in [200, 201, 202, 204]:
             return response.json()
         raise Exception(response.json())
+
+    def patch(self, url, payload):
+        response = requests.patch(url, headers=self.header, json=payload)
+        if response.status_code in [200, 201, 202, 204]:
+            return response.json()
+        raise Exception(response.json())
+

--- a/clockify_api_client/client.py
+++ b/clockify_api_client/client.py
@@ -6,6 +6,7 @@ from clockify_api_client.factories.time_entry_factory import TimeEntryFactory
 from clockify_api_client.factories.user_factory import UserFactory
 from clockify_api_client.factories.workspace_factory import WorkspaceFactory
 from clockify_api_client.factories.client_factory import ClientFactory
+from clockify_api_client.factories.custom_field_factory import CustomFieldFactory
 from clockify_api_client.utils import Singleton
 
 
@@ -19,6 +20,7 @@ class ClockifyAPIClient(metaclass=Singleton):
         self.users = None
         self.reports = None
         self.clients = None
+        self.custom_fields = None
 
     def build(self, api_key, api_url):
         """Builds services from available factories.
@@ -34,4 +36,5 @@ class ClockifyAPIClient(metaclass=Singleton):
         self.users = UserFactory(api_key=api_key, api_url=api_url)
         self.reports = ReportFactory(api_key=api_key, api_url=api_url)
         self.clients = ClientFactory(api_key=api_key, api_url=api_url)
+        self.custom_fields = CustomFieldFactory(api_key=api_key, api_url=api_url)
         return self

--- a/clockify_api_client/factories/custom_field_factory.py
+++ b/clockify_api_client/factories/custom_field_factory.py
@@ -1,0 +1,7 @@
+from clockify_api_client.factories.abstract_factory import AbstractFactory
+from clockify_api_client.models.custom_field import CustomField
+
+
+class CustomFieldFactory(AbstractFactory):
+    class Meta:
+        model = CustomField

--- a/clockify_api_client/models/client.py
+++ b/clockify_api_client/models/client.py
@@ -10,7 +10,7 @@ class Client(AbstractClockify):
         super(Client, self).__init__(api_key=api_key, api_url=api_url)
 
 
-    def add_client(self, workspace_id, name=None, note=None):
+    async def add_client(self, workspace_id, name=None, note=None):
         """Adds new client.
         :param workspace_id Id of workspace to look for clients.
         :param name         Name of the new client.
@@ -24,12 +24,12 @@ class Client(AbstractClockify):
                 'note' : note
             }
             url = self.base_url + '/workspaces/' + workspace_id + '/clients/'
-            return self.post(url, payload=data)
+            return await self.post(url, payload=data)
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e
 
-    def get_clients(self, workspace_id, params=None):
+    async def get_clients(self, workspace_id, params=None):
         """Returns all clients.
         :param workspace_id Id of workspace to look for clients.
         :param params       URL params of request.
@@ -41,7 +41,7 @@ class Client(AbstractClockify):
                 url = self.base_url + '/workspaces/' + workspace_id + '/clients?' + url_params
             else:
                 url = self.base_url + '/workspaces/' + workspace_id + '/clients/'
-            return self.get(url)
+            return await self.get(url)
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e

--- a/clockify_api_client/models/custom_field.py
+++ b/clockify_api_client/models/custom_field.py
@@ -9,7 +9,7 @@ class CustomField(AbstractClockify):
     def __init__(self, api_key, api_url):
         super(CustomField, self).__init__(api_key=api_key, api_url=api_url)
 
-    def get_custom_fields(self, workspace_id, params=None):
+    async def get_custom_fields(self, workspace_id, params=None):
         """Returns all custom fields in the workspace.
         :param workspace_id Id of workspace to look for custom fields.
         :param params       URL params of request.
@@ -21,12 +21,12 @@ class CustomField(AbstractClockify):
                 url = self.base_url + '/workspaces/' + workspace_id + '/custom-fields?' + url_params
             else:
                 url = self.base_url + '/workspaces/' + workspace_id + '/custom-fields/'
-            return self.get(url)
+            return await self.get(url)
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e
 
-    def get_project_custom_fields(self, workspace_id, project_id, params={'status': 'VISIBLE',}):
+    async def get_project_custom_fields(self, workspace_id, project_id, params={'status': 'VISIBLE',}):
         """Return the custom fields for a specific project.
         :param workspace_id Id of workspace containing the project.
         :param project_id   Id of project to look for custom fields.
@@ -36,12 +36,12 @@ class CustomField(AbstractClockify):
         try:
             url_params = urlencode(params, doseq=True)
             url = self.base_url + '/workspaces/' + workspace_id + '/projects/' + project_id + '/custom-fields?' + url_params
-            return self.get(url)
+            return await self.get(url)
         except Exception as e:
             logging.error('API error: {0}'.format(e))
             raise e
 
-    def update_project_custom_field(self, workspace_id, project_id, custom_field_id, value, isVisible=True):
+    async def update_project_custom_field(self, workspace_id, project_id, custom_field_id, value, isVisible=True):
         """Update specified custom field in the project.
         :param workspace_id    Id of workspace.
         :param project_id      Id of project.
@@ -61,7 +61,7 @@ class CustomField(AbstractClockify):
 
             url = self.base_url + '/workspace/' + workspace_id + '/projects/' + project_id + '/custom-fields/' + custom_field_id
 
-            return self.patch(url, custom_field_details)
+            return await self.patch(url, custom_field_details)
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e

--- a/clockify_api_client/models/custom_field.py
+++ b/clockify_api_client/models/custom_field.py
@@ -1,0 +1,67 @@
+import logging
+from urllib.parse import urlencode
+
+from clockify_api_client.abstract_clockify import AbstractClockify
+
+
+class CustomField(AbstractClockify):
+
+    def __init__(self, api_key, api_url):
+        super(CustomField, self).__init__(api_key=api_key, api_url=api_url)
+
+    def get_custom_fields(self, workspace_id, params=None):
+        """Returns all custom fields in the workspace.
+        :param workspace_id Id of workspace to look for custom fields.
+        :param params       URL params of request.
+        :return             List of custom fields (dict objects).
+        """
+        try:
+            if params:
+                url_params = urlencode(params, doseq=True)
+                url = self.base_url + '/workspaces/' + workspace_id + '/custom-fields?' + url_params
+            else:
+                url = self.base_url + '/workspaces/' + workspace_id + '/custom-fields/'
+            return self.get(url)
+        except Exception as e:
+            logging.error("API error: {0}".format(e))
+            raise e
+
+    def get_project_custom_fields(self, workspace_id, project_id, params={'status': 'VISIBLE',}):
+        """Return the custom fields for a specific project.
+        :param workspace_id Id of workspace containing the project.
+        :param project_id   Id of project to look for custom fields.
+        :param params       URL params of request.
+        :return             List of custom fields (dict objects).
+        """
+        try:
+            url_params = urlencode(params, doseq=True)
+            url = self.base_url + '/workspaces/' + workspace_id + '/projects/' + project_id + '/custom-fields?' + url_params
+            return self.get(url)
+        except Exception as e:
+            logging.error('API error: {0}'.format(e))
+            raise e
+
+    def update_project_custom_field(self, workspace_id, project_id, custom_field_id, value, isVisible=True):
+        """Update specified custom field in the project.
+        :param workspace_id    Id of workspace.
+        :param project_id      Id of project.
+        :param custom_field_id Id of custom field.
+        :param value           Value to set the custom field to.
+        :param isVisible       Boolean to set visibilty of the custom field.
+        :return                Dictionary of updated custom field.
+        """
+        try:
+            if isVisible:
+                status = "VISIBLE"
+            else:
+                status = "INVISIBLE"
+
+            custom_field_details = {'defaultValue': value,
+                                    'status': status}
+
+            url = self.base_url + '/workspace/' + workspace_id + '/projects/' + project_id + '/custom-fields/' + custom_field_id
+
+            return self.patch(url, custom_field_details)
+        except Exception as e:
+            logging.error("API error: {0}".format(e))
+            raise e

--- a/clockify_api_client/models/project.py
+++ b/clockify_api_client/models/project.py
@@ -9,12 +9,14 @@ class Project(AbstractClockify):
     def __init__(self, api_key, api_url):
         super(Project, self).__init__(api_key=api_key, api_url=api_url)
 
-    def get_projects(self, workspace_id, params=None):
+    async def get_projects(self, workspace_id, params=None):
         """Returns projects from given workspace with applied params if provided.
         :param workspace_id Id of workspace.
         :param params       Dictionary with request parameters.
         :return             List of projects.
         """
+        # TODO: Pagination should not be implemented in this way. It should be done in
+        #  the abstract class so that all methods can use it.
         try:
             page = 1
             all_projects = []
@@ -23,7 +25,7 @@ class Project(AbstractClockify):
                 params.update({"page": page, "page-size": 50})
                 url_params = urlencode(params, doseq=True)
                 url = self.base_url + '/workspaces/' + workspace_id + '/projects?' + url_params
-                response = self.get(url)
+                response = await self.get(url)
                 if not response:  # No more projects
                     break
                 all_projects.extend(response)
@@ -33,29 +35,30 @@ class Project(AbstractClockify):
             logging.error("API error: {0}".format(e))
             raise e
 
-
-    def add_project(self, workspace_id, project_name, client_id, billable=False, public=False, color="#16407B"):
+    async def add_project(self, workspace_id, project_name, client_id, billable=False, public=False, color="#16407B"):
         """Add new project into workspace.
         :param workspace_id Id of workspace.
         :param project_name Name of new project.
         :param client_id    Id of client.
-        :param billable     Bool flag.
+        :param billable     Bool flag. Indicates whether project is billable or not.
+        :param public       Bool flag. Indicates whether project is public or not.
+        :param color        Color code starting with # followed by 6 hex digits.
         :return             Dictionary representation of new project.
         """
         try:
             url = self.base_url + '/workspaces/' + workspace_id + '/projects/'
             data = {
-                'name': project_name,
+                "name": project_name,
                 "clientId": client_id,
                 "isPublic": "true" if public else "false",
                 "billable": billable
             }
-            return self.post(url, data)
+            return await self.post(url, data)
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e
 
-    def add_project_from_dict(self, workspace_id, project_dict):
+    async def add_project_from_dict(self, workspace_id, project_dict):
         """Add new project into workspace, built from a dictionary.
         :param workspace_id ID of workspace.
         :param project_dict Dictionary containing all the project details.
@@ -64,7 +67,7 @@ class Project(AbstractClockify):
         
         try:
             url = self.base_url + '/workspaces/' + workspace_id + '/projects/'
-            return self.post(url, project_dict)
+            return await self.post(url, project_dict)
         except Exception as e:
             logging.error('API error:{0}'.format(e))
             raise e

--- a/clockify_api_client/models/project.py
+++ b/clockify_api_client/models/project.py
@@ -16,15 +16,23 @@ class Project(AbstractClockify):
         :return             List of projects.
         """
         try:
-            if params:
+            page = 1
+            all_projects = []
+            while True:
+                params = params or {}
+                params.update({"page": page, "page-size": 50})
                 url_params = urlencode(params, doseq=True)
                 url = self.base_url + '/workspaces/' + workspace_id + '/projects?' + url_params
-            else:
-                url = self.base_url + '/workspaces/' + workspace_id + '/projects/'
-            return self.get(url)
+                response = self.get(url)
+                if not response:  # No more projects
+                    break
+                all_projects.extend(response)
+                page += 1
+            return all_projects
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e
+
 
     def add_project(self, workspace_id, project_name, client_id, billable=False, public=False, color="#16407B"):
         """Add new project into workspace.
@@ -46,3 +54,18 @@ class Project(AbstractClockify):
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e
+
+    def add_project_from_dict(self, workspace_id, project_dict):
+        """Add new project into workspace, built from a dictionary.
+        :param workspace_id ID of workspace.
+        :param project_dict Dictionary containing all the project details.
+        :return             Dictionary representation of new project.
+        """
+        
+        try:
+            url = self.base_url + '/workspaces/' + workspace_id + '/projects/'
+            return self.post(url, project_dict)
+        except Exception as e:
+            logging.error('API error:{0}'.format(e))
+            raise e
+

--- a/clockify_api_client/models/report.py
+++ b/clockify_api_client/models/report.py
@@ -8,7 +8,7 @@ class Report(AbstractClockify):
         super(Report, self).__init__(api_key=api_key, api_url=api_url)
         self.base_url = f'https://reports.{api_url}'.strip('/')
 
-    def get_summary_report(self, workspace_id, payload):
+    async def get_summary_report(self, workspace_id, payload):
         """Calls Clockify API for summary report. Returns summary report object(Dictionary)
         :param workspace_id Id of workspace for report.
         :param payload      Body of request for summary report.
@@ -16,12 +16,12 @@ class Report(AbstractClockify):
         """
         try:
             url = self.base_url + '/workspaces/' + workspace_id + '/reports/summary/'
-            return self.post(url, payload)
+            return await self.post(url, payload)
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e
 
-    def get_detailed_report(self, workspace_id, payload):
+    async def get_detailed_report(self, workspace_id, payload):
         """Calls Clockify API for detailed report. Returns detailed report object(Dictionary)
         :param workspace_id Id of workspace for report.
         :param payload      Body of request for detailed report.
@@ -29,12 +29,12 @@ class Report(AbstractClockify):
         """
         try:
             url = self.base_url + '/workspaces/' + workspace_id + '/reports/detailed/'
-            return self.post(url, payload)
+            return await self.post(url, payload)
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e
 
-    def get_weekly_report(self, workspace_id, payload):
+    async def get_weekly_report(self, workspace_id, payload):
         """Calls Clockify API for weekly report. Returns weekly report object(Dictionary)
         :param workspace_id Id of workspace for report.
         :param payload      Body of request for weekly report.
@@ -42,7 +42,7 @@ class Report(AbstractClockify):
         """
         try:
             url = self.base_url + '/workspaces/' + workspace_id + '/reports/weekly/'
-            return self.post(url, payload)
+            return await self.post(url, payload)
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e

--- a/clockify_api_client/models/tag.py
+++ b/clockify_api_client/models/tag.py
@@ -9,7 +9,7 @@ class Tag(AbstractClockify):
     def __init__(self, api_key, api_url):
         super(Tag, self).__init__(api_key=api_key, api_url=api_url)
 
-    def get_tags(self, workspace_id, params=None):
+    async def get_tags(self, workspace_id, params=None):
         """Gets list of tags from Clockify.
         :param workspace_id  Id of workspace.
         :param params        Request URL query parameters.
@@ -21,7 +21,7 @@ class Tag(AbstractClockify):
                 url = self.base_url + '/workspaces/' + workspace_id + '/tags?' + url_params
             else:
                 url = self.base_url + '/workspaces/' + workspace_id + '/tags/'
-            return self.get(url)
+            return await self.get(url)
 
         except Exception as e:
             logging.error("API error: {0}".format(e))

--- a/clockify_api_client/models/task.py
+++ b/clockify_api_client/models/task.py
@@ -9,7 +9,7 @@ class Task(AbstractClockify):
     def __init__(self, api_key, api_url):
         super(Task, self).__init__(api_key=api_key, api_url=api_url)
 
-    def add_task(self, workspace_id, project_id, task_name, request_data=None):
+    async def add_task(self, workspace_id, project_id, task_name, request_data=None):
         """Creates new task in Clockify.
         :param workspace_id  Id of workspace.
         :param request_data  Dictionary with request data.
@@ -22,12 +22,12 @@ class Task(AbstractClockify):
             payload = {'name': task_name, 'projectId': project_id}
             if request_data:
                 payload = {**payload, **request_data}
-            return self.post(url, payload)
+            return await self.post(url, payload)
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e
 
-    def update_task(self,  workspace_id, project_id, task_id, request_data=None):
+    async def update_task(self,  workspace_id, project_id, task_id, request_data=None):
         """Updates task in Clockify.
         :param workspace_id  Id of workspace.
         :param project_id    Id of project.
@@ -37,12 +37,12 @@ class Task(AbstractClockify):
         """
         try:
             url = self.base_url + '/workspaces/' + workspace_id + '/projects/' + project_id + '/tasks/' + task_id
-            return self.put(url, request_data)
+            return await self.put(url, request_data)
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e
 
-    def get_tasks(self, workspace_id, project_id, params=None):
+    async def get_tasks(self, workspace_id, project_id, params=None):
         """Gets list of tasks from Clockify.
         :param workspace_id  Id of workspace.
         :param project_id    Id of project.
@@ -55,13 +55,13 @@ class Task(AbstractClockify):
                 url = self.base_url + '/workspaces/' + workspace_id + '/projects/' + project_id + '/tasks?' + url_params
             else:
                 url = self.base_url + '/workspaces/' + workspace_id + '/projects/' + project_id + '/tasks/'
-            return self.get(url)
+            return await self.get(url)
 
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e
 
-    def get_task(self, workspace_id, project_id, task_id):
+    async def get_task(self, workspace_id, project_id, task_id):
         """Gets task from Clockify.
         :param workspace_id  Id of workspace.
         :param project_id    Id of project.
@@ -70,7 +70,7 @@ class Task(AbstractClockify):
         """
         try:
             url = self.base_url + '/workspaces/' + workspace_id + '/projects/' + project_id + '/tasks/' + task_id
-            return self.get(url)
+            return await self.get(url)
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e

--- a/clockify_api_client/models/time_entry.py
+++ b/clockify_api_client/models/time_entry.py
@@ -9,7 +9,7 @@ class TimeEntry(AbstractClockify):
     def __init__(self, api_key, api_url):
         super(TimeEntry, self).__init__(api_key=api_key, api_url=api_url)
 
-    def get_time_entries(self, workspace_id, user_id, params=None):
+    async def get_time_entries(self, workspace_id, user_id, params=None):
         """Returns user time entries.
         :param workspace_id Id of workspace.
         :param user_id      Id of user.
@@ -22,13 +22,13 @@ class TimeEntry(AbstractClockify):
                 url = self.base_url + '/workspaces/' + workspace_id + '/user/' + user_id + '/time-entries?' + url_params
             else:
                 url = self.base_url + '/workspaces/' + workspace_id + '/user/' + user_id + '/time-entries/'
-            time_entries_list = self.get(url)
+            time_entries_list = await self.get(url)
             return time_entries_list
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e
 
-    def get_time_entry(self, workspace_id, time_entry_id):
+    async def get_time_entry(self, workspace_id, time_entry_id):
         """Gets specific time entry.
         :param workspace_id  Id of workspace.
         :param time_entry_id Id of time entry
@@ -36,12 +36,12 @@ class TimeEntry(AbstractClockify):
         """
         try:
             url = self.base_url + '/workspaces/' + workspace_id + '/time-entries/' + time_entry_id
-            return self.get(url)
+            return await self.get(url)
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e
 
-    def update_time_entry(self, workspace_id, entry_id, payload):
+    async def update_time_entry(self, workspace_id, entry_id, payload):
         """Updates time entry in Clockify with provided payload data.
         :param workspace_id Id of workspace.
         :param entry_id     Id of time entry.
@@ -50,13 +50,13 @@ class TimeEntry(AbstractClockify):
         """
         try:
             url = self.base_url + '/workspaces/' + workspace_id + '/time-entries/' + entry_id
-            time_entry = self.put(url, payload)
+            time_entry = await self.put(url, payload)
             return time_entry
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e
 
-    def add_time_entry(self, workspace_id, user_id, payload):
+    async def add_time_entry(self, workspace_id, user_id, payload):
         """Adds time entry in Clockify with provided payload data.
         Paid feature, workspace need to have active paid subscription.
         :param workspace_id Id of workspace.
@@ -66,7 +66,7 @@ class TimeEntry(AbstractClockify):
         """
         try:
             url = self.base_url + '/workspaces/' + workspace_id + '/user/' + user_id + '/time-entries/'
-            time_entry = self.post(url, payload)
+            time_entry = await self.post(url, payload)
             return time_entry
         except Exception as e:
             logging.error("API error: {0}".format(e))

--- a/clockify_api_client/models/user.py
+++ b/clockify_api_client/models/user.py
@@ -9,18 +9,18 @@ class User(AbstractClockify):
     def __init__(self, api_key, api_url):
         super(User, self).__init__(api_key=api_key, api_url=api_url)
 
-    def get_current_user(self):
+    async def get_current_user(self):
         """Get user by paired with API key.
         :return User dictionary representation.
         """
         try:
             url = self.base_url + '/user/'
-            return self.get(url)
+            return await self.get(url)
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e
 
-    def get_users(self, workspace_id, params=None):
+    async def get_users(self, workspace_id, params=None):
         """Returns list of all users in given workspace.
         :param workspace_id Id of workspace.
         :param params       Request URL query params.
@@ -32,12 +32,12 @@ class User(AbstractClockify):
                 url = self.base_url + '/workspaces/' + workspace_id + '/users?' + params
             else:
                 url = self.base_url + '/workspaces/' + workspace_id + '/users/'
-            return self.get(url)
+            return await self.get(url)
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e
 
-    def add_user(self, workspace_id, email):
+    async def add_user(self, workspace_id, email):
         """Adds new user into workspace.
         :param workspace_id Id of workspace.
         :param email        Email of new user.
@@ -47,12 +47,12 @@ class User(AbstractClockify):
             emails = list()
             emails.append(email)
             data = {'emails': emails}
-            return self.post(url, data)
+            return await self.post(url, data)
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e
 
-    def update_user(self, workspace_id, user_id, payload):
+    async def update_user(self, workspace_id, user_id, payload):
         """Adds new user into workspace.
         :param workspace_id Id of workspace.
         :param user_id      User Id.
@@ -61,19 +61,19 @@ class User(AbstractClockify):
         """
         try:
             url = self.base_url + '/workspaces/' + workspace_id + '/users/' + user_id
-            return self.put(url, payload)
+            return await self.put(url, payload)
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e
 
-    def remove_user(self, workspace_id, user_id):
+    async def remove_user(self, workspace_id, user_id):
         """Removes user from workspace.
         :param workspace_id Id of workspace.
         :param user_id      User Id.
         """
         try:
             url = self.base_url + '/workspaces/' + workspace_id + '/users/' + user_id
-            return self.delete(url)
+            return await self.delete(url)
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e

--- a/clockify_api_client/models/workspace.py
+++ b/clockify_api_client/models/workspace.py
@@ -8,13 +8,13 @@ class Workspace(AbstractClockify):
     def __init__(self, api_key, api_url):
         super(Workspace, self).__init__(api_key=api_key, api_url=api_url)
 
-    def get_workspaces(self):
+    async def get_workspaces(self):
         """Returns all workspaces.
         :return List of Workspaces in dictionary representation.
         """
         try:
             url = self.base_url + '/workspaces/'
-            return self.get(url)
+            return await self.get(url)
         except Exception as e:
             logging.error("API error: {0}".format(e))
             raise e

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='clockify-api-client',
-    version='0.1.0',
+    version='0.2.0',
     author="Michael Bláha",
     author_email="michael.blaha@eluvia.com",
     description="Simple python API client for clockify. Inspired by https://pypi.org/project/clockify/library.",
@@ -13,7 +13,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/eluvia-com/clockify-api-aclient",
-    install_requires=['requests', 'factory_boy'],
+    install_requires=['httpx', 'factory_boy'],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This PR converts the Clockify API client from synchronous to asynchronous operation.

This is done by replacing `requests` calls with async calls to [httpx](https://www.python-httpx.org/).

A matching branch should be merged for [timekeeper](https://github.com/ion8/timekeeper) when this PR is merged.